### PR TITLE
Fix failed queue hrefs when using later version of Resque

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -1,18 +1,25 @@
 # resque-multiple-failure-backend
 
+## Compatibility
+
+Version 2.0 is known to work with v1.22.0 of the Resque gem in a Rails 5 app.
+If you are using an older version of Rails: use v1.1.1 of this gem alongside v1.13.0 of the Resque gem.
+
+Later versions of the resque (or the newer resque-web) gem appear to have let functionality of the views for multiple failure queues fall into an abyss.
+
 ## Usage
 
 ### In ~/resque_conf.rb
-  
+
     require 'resque/failure/multiple_failure'
     require 'resque/failure_server'
 
 ### In your worker application
-  
+
     Resque::Failure.backend = Resque::Failure::MultipleFailure
 
 ## Note on Patches/Pull Requests
- 
+
 * Fork the project.
 * Make your feature addition or bug fix.
 * Add tests for it. This is important so I don't break it in a

--- a/lib/resque/server/views/failures.erb
+++ b/lib/resque/server/views/failures.erb
@@ -17,7 +17,7 @@
   </tr>
   <% for queue in @queues.sort_by { |q| q.to_s } %>
   <tr class="<%= Resque::Failure.backend.count(queue).zero? ? "failed" : "failure" %>">
-    <td class='queue failed'><a class="queue" href="<%= url :failed, queue %>"><%= queue %></a></td>
+    <td class='queue failed'><a class="queue" href="<%= url "failed/#{queue}" %>"><%= queue %></a></td>
     <td class='size'><%= Resque::Failure.backend.count(queue) %></td>
   </tr>
   <% end %>

--- a/resque-multiple-failure-backend.gemspec
+++ b/resque-multiple-failure-backend.gemspec
@@ -5,7 +5,7 @@
 
 Gem::Specification.new do |s|
   s.name = %q{resque-multiple-failure-backend}
-  s.version = "1.1.1"
+  s.version = "2.0"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Adam Holt"]


### PR DESCRIPTION
Strap yourself in.

This line needs to be changed in order to use this gem in a Rails 5 app
(with Resque 1.22.0) and have working views.

Before this commit: this gem is known to work without issues with Resque
1.13.0 in a Rails 3.2 app. However:
- That version of resque has a dependency on json 1.4.6
- Ruby 2.2 is only compatible with > json 1.8
- Rails 5 is only compatible with >= ruby 2.2.2

Resque 1.22.0 is the highest version that removes the json 1.4.6
dependency whilst keeping fully working views for multiple failure
queues.

Despite newer versions of the Resque gem actually having the code from
this gem merged in - it doesn't appear that enough people use the
multiple failure queues behaviour because they haven't kept it working.
The newer resque-web gem also doesn't have working views for multiple
failure queues.